### PR TITLE
More resilent clientside rendering compatibility 

### DIFF
--- a/seven-minute-tabs.js
+++ b/seven-minute-tabs.js
@@ -6,7 +6,17 @@
 class SevenMinuteTabs extends HTMLElement {
   constructor() {
     super();
-
+    
+    this._init = this._init.bind(this);
+    this._observer = new MutationObserver(this._init);
+  }
+  connectedCallback() {
+    if (this.children.length) {
+      this._init();
+    }
+    this._observer.observe(this, { childList: true });
+  }
+  _init() {
     this.tablist = this.querySelector('[role="tablist"]');
     this.buttons = this.querySelectorAll('[role="tab"]');
     this.panels = this.querySelectorAll('[role="tabpanel"]');


### PR DESCRIPTION
This change makes the component initialization more compatible with clientside rendering frameworks (I verified the change within an Angular app). Basically, light dom often isn't there when the WC's constructor or connectedCallback runs in clientside rendering frameworks, because the callbacks fire when the parent element is rendered but not necessarily when the child HTML is there, so it errors out. This fixes that situation with a mutation observer, but it'll work the same in a regular page too.

More info here https://twitter.com/scottjehl/status/1318208894355836928