### PR TITLE
Support nested seven-minute-tab components (resolves #2)

### DIFF
--- a/seven-minute-tabs.js
+++ b/seven-minute-tabs.js
@@ -18,8 +18,8 @@ class SevenMinuteTabs extends HTMLElement {
   }
   _init() {
     this.tablist = this.querySelector('[role="tablist"]');
-    this.buttons = this.querySelectorAll('[role="tab"]');
-    this.panels = this.querySelectorAll('[role="tabpanel"]');
+    this.buttons = this.tablist.querySelectorAll('[role="tab"]');
+    this.panels = this.querySelectorAll(':scope > [role="tabpanel"]');
     this.delay = this.determineDelay();
 
     if(!this.tablist || !this.buttons.length || !this.panels.length) {
@@ -66,7 +66,7 @@ class SevenMinuteTabs extends HTMLElement {
   }
 
   initPanels() {
-    let selectedPanelId = this.querySelector('[role="tab"][aria-selected="true"]').getAttribute("aria-controls");
+    let selectedPanelId = this.tablist.querySelector('[role="tab"][aria-selected="true"]').getAttribute("aria-controls");
     for(let panel of this.panels) {
       if(panel.getAttribute("id") !== selectedPanelId) {
         panel.setAttribute("hidden", "");


### PR DESCRIPTION
As proposed in #2, this PR allows `<seven-minute-tabs>` components to be nested (so a tab panel could have another `<seven-minute-tabs>` component within it).